### PR TITLE
[H02] Users can exercise small amounts without sending collateral

### DIFF
--- a/smart-contracts/contracts/core/ACOFactory.sol
+++ b/smart-contracts/contracts/core/ACOFactory.sol
@@ -113,15 +113,17 @@ contract ACOFactory {
      * @param isCall Whether the ACO token is the Call type.
      * @param strikePrice The strike price with the strike asset precision.
      * @param expiryTime The UNIX time for the ACO token expiration.
+     * @param maxExercisedAccounts The maximum number of accounts that can be exercised by transaction.
      */
     function createAcoToken(
         address underlying, 
         address strikeAsset, 
         bool isCall,
         uint256 strikePrice, 
-        uint256 expiryTime
+        uint256 expiryTime,
+        uint256 maxExercisedAccounts
     ) onlyFactoryAdmin external virtual {
-        address acoToken = _deployAcoToken(_getAcoTokenInitData(underlying, strikeAsset, isCall, strikePrice, expiryTime));
+        address acoToken = _deployAcoToken(_getAcoTokenInitData(underlying, strikeAsset, isCall, strikePrice, expiryTime, maxExercisedAccounts));
         emit NewAcoToken(underlying, strikeAsset, isCall, strikePrice, expiryTime, acoToken, acoTokenImplementation);   
     }
     
@@ -207,6 +209,7 @@ contract ACOFactory {
      * @param isCall True if the type is CALL, false for PUT.
      * @param strikePrice The strike price with the strike asset precision.
      * @param expiryTime The UNIX time for the ACO token expiration.
+     * @param maxExercisedAccounts The maximum number of accounts that can be exercised by transaction.
      * @return ABI encoded with signature for initializing ACO token.
      */
     function _getAcoTokenInitData(
@@ -214,16 +217,18 @@ contract ACOFactory {
         address strikeAsset, 
         bool isCall,
         uint256 strikePrice, 
-        uint256 expiryTime
+        uint256 expiryTime,
+        uint256 maxExercisedAccounts
     ) internal view virtual returns(bytes memory) {
-        return abi.encodeWithSignature("init(address,address,bool,uint256,uint256,uint256,address)",
+        return abi.encodeWithSignature("init(address,address,bool,uint256,uint256,uint256,address,uint256)",
             underlying,
             strikeAsset,
             isCall,
             strikePrice,
             expiryTime,
             acoFee,
-            acoFeeDestination
+            acoFeeDestination,
+            maxExercisedAccounts
         );
     }
     

--- a/smart-contracts/contracts/interfaces/IACOToken.sol
+++ b/smart-contracts/contracts/interfaces/IACOToken.sol
@@ -14,6 +14,7 @@ interface IACOToken is IERC20 {
     function expiryTime() external view returns (uint256);
     function totalCollateral() external view returns (uint256);
     function acoFee() external view returns (uint256);
+	function maxExercisedAccounts() external view returns (uint256);
     function underlyingSymbol() external view returns (string memory);
     function strikeAssetSymbol() external view returns (string memory);
     function underlyingDecimals() external view returns (uint8);
@@ -26,7 +27,8 @@ interface IACOToken is IERC20 {
     function assignableTokens(address account) external view returns(uint256);
     function getCollateralAmount(uint256 tokenAmount) external view returns(uint256);
     function getTokenAmount(uint256 collateralAmount) external view returns(uint256);
-    function getExerciseData(uint256 tokenAmount) external view returns(address, uint256);
+    function getBaseExerciseData(uint256 tokenAmount) external view returns(address, uint256);
+    function numberOfAccountsWithCollateral() external view returns(uint256);
     function getCollateralOnExercise(uint256 tokenAmount) external view returns(uint256, uint256);
     function collateral() external view returns(address);
     function mintPayable() external payable;

--- a/smart-contracts/contracts/only-for-tests/ACOFactoryForTest.sol
+++ b/smart-contracts/contracts/only-for-tests/ACOFactoryForTest.sol
@@ -23,9 +23,10 @@ contract ACOFactoryForTest is ACOFactory {
         address strikeAsset, 
         bool isCall,
         uint256 strikePrice, 
-        uint256 expiryTime
+        uint256 expiryTime,
+        uint256 maxExercisedAccounts
     ) external override {
-        address acoToken = _deployAcoToken(_getAcoTokenInitData(underlying, strikeAsset, isCall, strikePrice, expiryTime));
+        address acoToken = _deployAcoToken(_getAcoTokenInitData(underlying, strikeAsset, isCall, strikePrice, expiryTime, maxExercisedAccounts));
         emit NewAcoToken(underlying, strikeAsset, isCall, strikePrice, expiryTime, acoToken, acoTokenImplementation);   
     }
     


### PR DESCRIPTION
All minter payment on exercise was added 1 to guarantee that the minter will be paid at least by 1 minimum value. So the exerciser needs to send a little more to exercise: maxExercisedAccounts (new storage value per token) when using standard function OR accounts.length when using exerciseAccounts or exerciseAccountsFrom functions