### PR TITLE
[L01] Using .call for init is not flexible

### DIFF
--- a/smart-contracts/contracts/core/ACOFactory.sol
+++ b/smart-contracts/contracts/core/ACOFactory.sol
@@ -113,15 +113,17 @@ contract ACOFactory {
      * @param isCall Whether the ACO token is the Call type.
      * @param strikePrice The strike price with the strike asset precision.
      * @param expiryTime The UNIX time for the ACO token expiration.
+     * @param maxExercisedAccounts The maximum number of accounts that can be exercised by transaction.
      */
     function createAcoToken(
         address underlying, 
         address strikeAsset, 
         bool isCall,
         uint256 strikePrice, 
-        uint256 expiryTime
+        uint256 expiryTime,
+        uint256 maxExercisedAccounts
     ) onlyFactoryAdmin external virtual {
-        address acoToken = _deployAcoToken(_getAcoTokenInitData(underlying, strikeAsset, isCall, strikePrice, expiryTime));
+        address acoToken = _deployAcoToken(_getAcoTokenInitData(underlying, strikeAsset, isCall, strikePrice, expiryTime, maxExercisedAccounts));
         emit NewAcoToken(underlying, strikeAsset, isCall, strikePrice, expiryTime, acoToken, acoTokenImplementation);   
     }
     
@@ -207,6 +209,7 @@ contract ACOFactory {
      * @param isCall True if the type is CALL, false for PUT.
      * @param strikePrice The strike price with the strike asset precision.
      * @param expiryTime The UNIX time for the ACO token expiration.
+     * @param maxExercisedAccounts The maximum number of accounts that can be exercised by transaction.
      * @return ABI encoded with signature for initializing ACO token.
      */
     function _getAcoTokenInitData(
@@ -214,16 +217,18 @@ contract ACOFactory {
         address strikeAsset, 
         bool isCall,
         uint256 strikePrice, 
-        uint256 expiryTime
+        uint256 expiryTime,
+        uint256 maxExercisedAccounts
     ) internal view virtual returns(bytes memory) {
-        return abi.encodeWithSignature("init(address,address,bool,uint256,uint256,uint256,address)",
+        return abi.encodeWithSignature("init(address,address,bool,uint256,uint256,uint256,address,uint256)",
             underlying,
             strikeAsset,
             isCall,
             strikePrice,
             expiryTime,
             acoFee,
-            acoFeeDestination
+            acoFeeDestination,
+            maxExercisedAccounts
         );
     }
     

--- a/smart-contracts/contracts/core/ACOFactory.sol
+++ b/smart-contracts/contracts/core/ACOFactory.sol
@@ -1,8 +1,7 @@
 pragma solidity ^0.6.6;
 
 import "../libs/Address.sol";
-import "../libs/BokkyPooBahsDateTimeLibrary.sol";
-import "../libs/Strings.sol";
+import "../interfaces/IACOToken.sol";
 
 /**
  * @title ACOFactory
@@ -123,7 +122,7 @@ contract ACOFactory {
         uint256 expiryTime,
         uint256 maxExercisedAccounts
     ) onlyFactoryAdmin external virtual {
-        address acoToken = _deployAcoToken(_getAcoTokenInitData(underlying, strikeAsset, isCall, strikePrice, expiryTime, maxExercisedAccounts));
+        address acoToken = _deployAcoToken(underlying, strikeAsset, isCall, strikePrice, expiryTime, maxExercisedAccounts);
         emit NewAcoToken(underlying, strikeAsset, isCall, strikePrice, expiryTime, acoToken, acoTokenImplementation);   
     }
     
@@ -203,42 +202,23 @@ contract ACOFactory {
     }
     
     /**
-     * @dev Internal function to get the ACO token initialize data.
+     * @dev Internal function to deploy a minimal proxy using ACO token implementation.
      * @param underlying Address of the underlying asset (0x0 for Ethereum).
      * @param strikeAsset Address of the strike asset (0x0 for Ethereum).
      * @param isCall True if the type is CALL, false for PUT.
      * @param strikePrice The strike price with the strike asset precision.
      * @param expiryTime The UNIX time for the ACO token expiration.
      * @param maxExercisedAccounts The maximum number of accounts that can be exercised by transaction.
-     * @return ABI encoded with signature for initializing ACO token.
+     * @return Address of the new minimal proxy deployed for the ACO token.
      */
-    function _getAcoTokenInitData(
+    function _deployAcoToken(
         address underlying, 
         address strikeAsset, 
         bool isCall,
         uint256 strikePrice, 
         uint256 expiryTime,
         uint256 maxExercisedAccounts
-    ) internal view virtual returns(bytes memory) {
-        return abi.encodeWithSignature("init(address,address,bool,uint256,uint256,uint256,address,uint256)",
-            underlying,
-            strikeAsset,
-            isCall,
-            strikePrice,
-            expiryTime,
-            acoFee,
-            acoFeeDestination,
-            maxExercisedAccounts
-        );
-    }
-    
-    /**
-     * @dev Internal function to deploy a minimal proxy using ACO token implementation.
-     * @param initData ABI encoded with signature for initializing the new ACO token.
-     * @return Address of the new minimal proxy deployed for the ACO token.
-     */
-    function _deployAcoToken(bytes memory initData) internal virtual returns(address) {
-        require(initData.length > 0, "ACOFactory::_deployToken: Invalid init data");
+    ) internal virtual returns(address) {
         bytes20 implentationBytes = bytes20(acoTokenImplementation);
         address proxy;
         assembly {
@@ -248,27 +228,7 @@ contract ACOFactory {
             mstore(add(clone, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
             proxy := create(0, clone, 0x37)
         }
-        (bool success, bytes memory returnData) = proxy.call(initData);
-        require(success, _acoTokenInititalizeError(returnData));
+        IACOToken(proxy).init(underlying, strikeAsset, isCall, strikePrice, expiryTime, acoFee, payable(acoFeeDestination), maxExercisedAccounts);
         return proxy;
-    }
-    
-    /**
-     * @dev Internal function to handle the return data on initializing ACO token with an error.
-     * 4 bytes (function signature) + 32 bytes (offset) + 32 bytes (error string length) + X bytes (error string)
-     * @param data Returned data with an error.
-     * @return String with the error.
-     */
-    function _acoTokenInititalizeError(bytes memory data) internal pure virtual returns(string memory) {
-        if (data.length >= 100) {
-            bytes memory buffer = new bytes(data.length - 68);
-            uint256 index = 0;
-            for (uint256 i = 68; i < data.length; ++i) {
-                buffer[index++] = data[i];
-            }
-            return string(buffer);
-        } else {
-            return "ACOFactory::_acoTokenInititalizeError";
-        }  
     }
 }

--- a/smart-contracts/contracts/interfaces/IACOToken.sol
+++ b/smart-contracts/contracts/interfaces/IACOToken.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.6.6;
 import "./IERC20.sol";
 
 interface IACOToken is IERC20 {
+	function init(address _underlying, address _strikeAsset, bool _isCall, uint256 _strikePrice, uint256 _expiryTime, uint256 _acoFee, address payable _feeDestination, uint256 _maxExercisedAccounts) external;
     function name() external view returns(string memory);
     function symbol() external view returns(string memory);
     function decimals() external view returns(uint8);

--- a/smart-contracts/contracts/interfaces/IACOToken.sol
+++ b/smart-contracts/contracts/interfaces/IACOToken.sol
@@ -14,6 +14,7 @@ interface IACOToken is IERC20 {
     function expiryTime() external view returns (uint256);
     function totalCollateral() external view returns (uint256);
     function acoFee() external view returns (uint256);
+	function maxExercisedAccounts() external view returns (uint256);
     function underlyingSymbol() external view returns (string memory);
     function strikeAssetSymbol() external view returns (string memory);
     function underlyingDecimals() external view returns (uint8);
@@ -26,7 +27,8 @@ interface IACOToken is IERC20 {
     function assignableTokens(address account) external view returns(uint256);
     function getCollateralAmount(uint256 tokenAmount) external view returns(uint256);
     function getTokenAmount(uint256 collateralAmount) external view returns(uint256);
-    function getExerciseData(uint256 tokenAmount) external view returns(address, uint256);
+    function getBaseExerciseData(uint256 tokenAmount) external view returns(address, uint256);
+    function numberOfAccountsWithCollateral() external view returns(uint256);
     function getCollateralOnExercise(uint256 tokenAmount) external view returns(uint256, uint256);
     function collateral() external view returns(address);
     function mintPayable() external payable;

--- a/smart-contracts/contracts/only-for-tests/ACOFactoryForTest.sol
+++ b/smart-contracts/contracts/only-for-tests/ACOFactoryForTest.sol
@@ -26,7 +26,7 @@ contract ACOFactoryForTest is ACOFactory {
         uint256 expiryTime,
         uint256 maxExercisedAccounts
     ) external override {
-        address acoToken = _deployAcoToken(_getAcoTokenInitData(underlying, strikeAsset, isCall, strikePrice, expiryTime, maxExercisedAccounts));
+        address acoToken = _deployAcoToken(underlying, strikeAsset, isCall, strikePrice, expiryTime, maxExercisedAccounts);
         emit NewAcoToken(underlying, strikeAsset, isCall, strikePrice, expiryTime, acoToken, acoTokenImplementation);   
     }
     

--- a/smart-contracts/contracts/only-for-tests/ACOFactoryForTest.sol
+++ b/smart-contracts/contracts/only-for-tests/ACOFactoryForTest.sol
@@ -23,9 +23,10 @@ contract ACOFactoryForTest is ACOFactory {
         address strikeAsset, 
         bool isCall,
         uint256 strikePrice, 
-        uint256 expiryTime
+        uint256 expiryTime,
+        uint256 maxExercisedAccounts
     ) external override {
-        address acoToken = _deployAcoToken(_getAcoTokenInitData(underlying, strikeAsset, isCall, strikePrice, expiryTime));
+        address acoToken = _deployAcoToken(_getAcoTokenInitData(underlying, strikeAsset, isCall, strikePrice, expiryTime, maxExercisedAccounts));
         emit NewAcoToken(underlying, strikeAsset, isCall, strikePrice, expiryTime, acoToken, acoTokenImplementation);   
     }
     


### PR DESCRIPTION
[L01] Changing for use IACOToken interface to call the init method instead of a low-level function